### PR TITLE
🤖 Configurar Dependabot para actualizaciones automáticas

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# Configuración de Dependabot
+# Docs: https://docs.github.com/es/code-security/dependabot
+
+version: 2
+
+updates:
+  # Actualizar dependencias de Python (pip)
+  - package-ecosystem: "pip"
+    directory: "/"  # Busca requirements.txt en la raíz
+    schedule:
+      interval: "weekly"  # Revisa cada semana
+      day: "monday"       # Los lunes
+      time: "09:00"       # A las 9:00 AM
+      timezone: "Europe/Madrid"
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "⬆️ pip:"
+    open-pull-requests-limit: 5  # Máximo 5 PRs abiertos a la vez
+
+  # Actualizar GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "ci-cd"
+    commit-message:
+      prefix: "⬆️ actions:"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## 📋 Descripción

Este PR configura **Dependabot** para que GitHub nos avise automáticamente cuando haya actualizaciones disponibles para nuestras dependencias.

## 🔗 Issue relacionado

Closes #8

## ✨ Cambios realizados

- ✅ Crear archivo `.github/dependabot.yml`
- ✅ Configurar actualización de dependencias Python (pip) semanalmente
- ✅ Configurar actualización de GitHub Actions semanalmente
- ✅ Programar revisiones los lunes a las 9:00 AM (Europe/Madrid)
- ✅ Configurar labels automáticas para los PRs
- ✅ Limitar PRs abiertos simultáneamente (5 para pip, 3 para actions)

## 🔍 Qué hace esta configuración

| Ecosystem | Frecuencia | Día | Labels |
|-----------|------------|-----|--------|
| pip (Python) | Semanal | Lunes 9:00 | `dependencies`, `python` |
| github-actions | Semanal | Lunes | `dependencies`, `ci-cd` |

## 🧪 Cómo verificar

1. Hacer merge del PR
2. Ir a **Insights** → **Dependency graph** → **Dependabot**
3. Verificar que aparece la configuración
4. Dependabot creará PRs automáticamente cuando detecte actualizaciones

## 📁 Archivos modificados

- `.github/dependabot.yml` (nuevo)